### PR TITLE
@pedrro - Removendo erro no package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.13.3",
-    "express": "^4.13.3",
+    "express": "^4.13.3"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
O package.json tinha uma virgula a mais que estava impossibilitando a instalação de dependências via npm.
